### PR TITLE
Option for xhtml template for EPUB and a bug fix

### DIFF
--- a/lib/atom-html-templates.coffee
+++ b/lib/atom-html-templates.coffee
@@ -7,10 +7,10 @@ module.exports = AtomHtmlTemplates =
         @templateForm = ""
         @additionalStyles = []
         @additionalJs = []
-        @defaultStyles = '<link rel="stylesheet" href="PATH">'
-        @defaultCharset = '<meta charset="UTF-8">'
+        @defaultStyles = '<link rel="stylesheet" href="PATH" />'
+        @defaultCharset = '<meta charset="UTF-8" />'
         @defaultTitle = '<title>TITLE</title>'
-        @defaultDescription = '<meta name="description" content="DESCRIPTION">'
+        @defaultDescription = '<meta name="description" content="DESCRIPTION" />'
         @defaultLanguage = 'en'
         # @modalPanel = atom.workspace.addModalPanel(item: @atomHtmlTemplatesView.getElement(), visible: false)
 

--- a/lib/atom-html-templates.coffee
+++ b/lib/atom-html-templates.coffee
@@ -10,6 +10,27 @@ module.exports = AtomHtmlTemplates =
         @defaultStyles = '<link rel = "stylesheet" href="RUTA">'
         # @modalPanel = atom.workspace.addModalPanel(item: @atomHtmlTemplatesView.getElement(), visible: false)
 
+        @defaultHTML = """
+                               <html lang="es">
+
+                               <head>
+                                   <meta charset="UTF-8">
+                                   <title>Título</title>
+                                   <meta name="description" content="Descripción">
+                                   #{@defaultStyles}
+                                   #{@returnAdd(@additionalStyles)}
+                                   <!-- Para compatibilidad con Internet Explorer 9 -->
+                                   <!--[if lt IE 9]>
+                                     <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+                                   <![endif]-->
+                               </head>
+
+                               <body>
+                               #{@returnAdd(@additionalJs)}
+                               </body>
+
+                               </html>
+                       """
         # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
         @subscriptions = new CompositeDisposable
 
@@ -58,28 +79,14 @@ module.exports = AtomHtmlTemplates =
             if valueArr[0] == "html5"
                 @templateForm = """
                                 <!DOCTYPE html>
-                                <html lang="es">
-
-                                <head>
-                                    <meta charset="UTF-8">
-                                    <title>Título</title>
-                                    <meta name="description" content="Descripción">
-                                    #{@defaultStyles}
-                                    #{@returnAdd(@additionalStyles)}
-                                    <!-- Para compatibilidad con Internet Explorer 9 -->
-                                    <!--[if lt IE 9]>
-                                      <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-                                    <![endif]-->
-                                </head>
-
-                                <body>
-                                #{@returnAdd(@additionalJs)}
-                                </body>
-
-                                </html>
+                                #{@defaultHTML}
                                 """
-            else if valueArr[0] == "xhtml"
-                @templateForm="XHTML"
+            else if valueArr[0] == "epub"
+                @templateForm= """
+                               <?xml version="1.0" encoding="UTF-8"?>
+                               <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="es" lang="es">
+                               #{@defaultHTML}
+                                """
             else
                 @templateForm="No existe tal opción."
 

--- a/lib/atom-html-templates.coffee
+++ b/lib/atom-html-templates.coffee
@@ -4,14 +4,14 @@ module.exports = AtomHtmlTemplates =
     subscriptions: null
 
     activate: (state) ->
-        @templateForm=""
-        @additionalStyles=[]
+        @templateForm = ""
+        @additionalStyles = []
         @additionalJs = []
-        @defaultStyles = '<link rel = "stylesheet" href="PATH">'
+        @defaultStyles = '<link rel="stylesheet" href="PATH">'
         @defaultCharset = '<meta charset="UTF-8">'
-        @defaultTitle = '<title>Título</title>'
-        @defaultDescription = '<meta name="description" content="Descripción">'
-        @defaultLanguage = 'es'
+        @defaultTitle = '<title>TITLE</title>'
+        @defaultDescription = '<meta name="description" content="DESCRIPTION">'
+        @defaultLanguage = 'en'
         # @modalPanel = atom.workspace.addModalPanel(item: @atomHtmlTemplatesView.getElement(), visible: false)
 
         # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
@@ -49,7 +49,6 @@ module.exports = AtomHtmlTemplates =
                 scripts +=array[i]
         return scripts
 
-
     toggle: ->
         defaultGrammarScopeName = "text.html.basic"
         if editor=atom.workspace.getActiveTextEditor()
@@ -63,6 +62,7 @@ module.exports = AtomHtmlTemplates =
                 @templateForm = """
                                 <!DOCTYPE html>
                                 <html lang="#{@defaultLanguage}">
+
                                 <head>
                                     #{@defaultCharset}
                                     #{@defaultTitle}
@@ -84,6 +84,7 @@ module.exports = AtomHtmlTemplates =
                 @templateForm= """
                                <?xml version="1.0" encoding="UTF-8"?>
                                <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="#{@defaultLanguage}" lang="#{@defaultLanguage}">
+
                                <head>
                                    #{@defaultCharset}
                                    #{@defaultTitle}
@@ -101,3 +102,7 @@ module.exports = AtomHtmlTemplates =
 
         editor.setText(@templateForm)
         editor.setGrammar(atom.grammars.grammarForScopeName(defaultGrammarScopeName))
+
+        # Refresh
+        @additionalStyles = []
+        @additionalJs = []

--- a/lib/atom-html-templates.coffee
+++ b/lib/atom-html-templates.coffee
@@ -61,21 +61,20 @@ module.exports = AtomHtmlTemplates =
               <html lang="es">
 
               <head>
-                <meta charset ="utf-8">
-                <title>Título</title>
-                <meta name = "description" content="Descripción">
-
-                #{@returnAdd(@additionalStyles)}
-                #{@defaultStyles}
-
-                <!-- Para compatibilidad con Internet Explorer 9 -->
-                <!--[if lt IE 9]>
-                <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-                <![endif]-->
+                  <meta charset="UTF-8">
+                  <title>Título</title>
+                  <meta name="description" content="Descripción">
+                  <link rel="stylesheet" href="RUTA">
+                  #{@returnAdd(@additionalStyles)}
+                  #{@defaultStyles}
+                  <!-- Para compatibilidad con Internet Explorer 9 -->
+                  <!--[if lt IE 9]>
+                    <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+                  <![endif]-->
               </head>
 
               <body>
-                #{@returnAdd(@additionalJs)}
+              #{@returnAdd(@additionalJs)}
 
               </body>
 

--- a/lib/atom-html-templates.coffee
+++ b/lib/atom-html-templates.coffee
@@ -7,29 +7,13 @@ module.exports = AtomHtmlTemplates =
         @templateForm=""
         @additionalStyles=[]
         @additionalJs = []
-        @defaultStyles = '<link rel = "stylesheet" href="RUTA">'
+        @defaultStyles = '<link rel = "stylesheet" href="PATH">'
+        @defaultCharset = '<meta charset="UTF-8">'
+        @defaultTitle = '<title>Título</title>'
+        @defaultDescription = '<meta name="description" content="Descripción">'
+        @defaultLanguage = 'es'
         # @modalPanel = atom.workspace.addModalPanel(item: @atomHtmlTemplatesView.getElement(), visible: false)
 
-        @defaultHTML = """
-
-                               <head>
-                                   <meta charset="UTF-8">
-                                   <title>Título</title>
-                                   <meta name="description" content="Descripción">
-                                   #{@defaultStyles}
-                                   #{@returnAdd(@additionalStyles)}
-                                   <!-- Para compatibilidad con Internet Explorer 9 -->
-                                   <!--[if lt IE 9]>
-                                     <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-                                   <![endif]-->
-                               </head>
-
-                               <body>
-                               #{@returnAdd(@additionalJs)}
-                               </body>
-
-                               </html>
-                       """
         # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
         @subscriptions = new CompositeDisposable
 
@@ -78,17 +62,42 @@ module.exports = AtomHtmlTemplates =
             if valueArr[0] == "html5"
                 @templateForm = """
                                 <!DOCTYPE html>
-                                <html lang="es">
-                                #{@defaultHTML}
+                                <html lang="#{@defaultLanguage}">
+                                <head>
+                                    #{@defaultCharset}
+                                    #{@defaultTitle}
+                                    #{@defaultDescription}
+                                    #{@defaultStyles}
+                                    #{@returnAdd(@additionalStyles)}
+                                    <!--[if lt IE 9]>
+                                      <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+                                    <![endif]-->
+                                </head>
+
+                                <body>
+                                #{@returnAdd(@additionalJs)}
+                                </body>
+
+                                </html>
                                 """
             else if valueArr[0] == "epub"
                 @templateForm= """
                                <?xml version="1.0" encoding="UTF-8"?>
-                               <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="es" lang="es">
-                               #{@defaultHTML}
+                               <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="#{@defaultLanguage}" lang="#{@defaultLanguage}">
+                               <head>
+                                   #{@defaultCharset}
+                                   #{@defaultTitle}
+                                   #{@defaultStyles}
+                               </head>
+
+                               <body epub:type="TYPE">
+
+                               </body>
+
+                               </html>
                                 """
             else
-                @templateForm="No existe tal opción."
+                @templateForm="There is no such option."
 
         editor.setText(@templateForm)
         editor.setGrammar(atom.grammars.grammarForScopeName(defaultGrammarScopeName))

--- a/lib/atom-html-templates.coffee
+++ b/lib/atom-html-templates.coffee
@@ -36,7 +36,7 @@ module.exports = AtomHtmlTemplates =
         @additionalStyles[indeksS++]= '<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">'
       else if array[i] == 'mdi'
         @additionalStyles[indeksS++]= '<link rel="stylesheet" href="https://cdn.materialdesignicons.com/1.4.57/css/materialdesignicons.min.css">'
-  
+
   returnAdd: (array) ->
     scripts = " "
     for i in [0...array.length] by 1
@@ -57,30 +57,32 @@ module.exports = AtomHtmlTemplates =
        console.log(@additionalStyles)
        if valueArr[0] == "html5"
            @templateForm = """
-              <!doctype html>
-              <html lang="en">
+              <!DOCTYPE html>
+              <html lang="es">
+
               <head>
                 <meta charset ="utf-8">
-
-                <title>Title of your project</title>
-                <meta name = "description" content="The HTML5 Herald">
-                <meta name = "author" content="SitePoint">
+                <title>Título</title>
+                <meta name = "description" content="Descripción">
 
                 #{@returnAdd(@additionalStyles)}
                 #{@defaultStyles}
 
+                <!-- Para compatibilidad con Internet Explorer 9 -->
                 <!--[if lt IE 9]>
                 <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
                 <![endif]-->
               </head>
+
               <body>
                 #{@returnAdd(@additionalJs)}
-                <script src = "js/scripts.js"></script>
+
               </body>
+
               </html>
               """
        else
-        @templateForm="nie ma takiej opcji"
+        @templateForm="No existe tal opción."
 
     editor.setText(@templateForm)
     editor.setGrammar(atom.grammars.grammarForScopeName(defaultGrammarScopeName))

--- a/lib/atom-html-templates.coffee
+++ b/lib/atom-html-templates.coffee
@@ -7,7 +7,7 @@ module.exports = AtomHtmlTemplates =
     @templateForm=""
     @additionalStyles=[]
     @additionalJs = []
-    @defaultStyles = '<link rel = "stylesheet" href="css/styles.css?v=1.0">'
+    @defaultStyles = '<link rel = "stylesheet" href="RUTA">'
     # @modalPanel = atom.workspace.addModalPanel(item: @atomHtmlTemplatesView.getElement(), visible: false)
 
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
@@ -64,7 +64,6 @@ module.exports = AtomHtmlTemplates =
                   <meta charset="UTF-8">
                   <title>Título</title>
                   <meta name="description" content="Descripción">
-                  <link rel="stylesheet" href="RUTA">
                   #{@returnAdd(@additionalStyles)}
                   #{@defaultStyles}
                   <!-- Para compatibilidad con Internet Explorer 9 -->
@@ -75,7 +74,6 @@ module.exports = AtomHtmlTemplates =
 
               <body>
               #{@returnAdd(@additionalJs)}
-
               </body>
 
               </html>

--- a/lib/atom-html-templates.coffee
+++ b/lib/atom-html-templates.coffee
@@ -11,7 +11,6 @@ module.exports = AtomHtmlTemplates =
         # @modalPanel = atom.workspace.addModalPanel(item: @atomHtmlTemplatesView.getElement(), visible: false)
 
         @defaultHTML = """
-                               <html lang="es">
 
                                <head>
                                    <meta charset="UTF-8">
@@ -79,6 +78,7 @@ module.exports = AtomHtmlTemplates =
             if valueArr[0] == "html5"
                 @templateForm = """
                                 <!DOCTYPE html>
+                                <html lang="es">
                                 #{@defaultHTML}
                                 """
             else if valueArr[0] == "epub"

--- a/lib/atom-html-templates.coffee
+++ b/lib/atom-html-templates.coffee
@@ -1,85 +1,87 @@
 {CompositeDisposable} = require 'atom'
 
 module.exports = AtomHtmlTemplates =
-  subscriptions: null
+    subscriptions: null
 
-  activate: (state) ->
-    @templateForm=""
-    @additionalStyles=[]
-    @additionalJs = []
-    @defaultStyles = '<link rel = "stylesheet" href="RUTA">'
-    # @modalPanel = atom.workspace.addModalPanel(item: @atomHtmlTemplatesView.getElement(), visible: false)
+    activate: (state) ->
+        @templateForm=""
+        @additionalStyles=[]
+        @additionalJs = []
+        @defaultStyles = '<link rel = "stylesheet" href="RUTA">'
+        # @modalPanel = atom.workspace.addModalPanel(item: @atomHtmlTemplatesView.getElement(), visible: false)
 
-    # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
-    @subscriptions = new CompositeDisposable
+        # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
+        @subscriptions = new CompositeDisposable
 
-    # Register command that toggles this view
-    @subscriptions.add atom.commands.add 'atom-workspace', 'atom-html-templates:toggle': => @toggle()
+        # Register command that toggles this view
+        @subscriptions.add atom.commands.add 'atom-workspace', 'atom-html-templates:toggle': => @toggle()
 
-  deactivate: ->
-    @subscriptions.dispose()
+    deactivate: ->
+        @subscriptions.dispose()
 
-  addResource: (array) ->
-    indeksS = indeksJ = 0
-    for i in [0...array.length] by 1
-      if array[i] == 'bootstrap'
-        @additionalStyles[indeksS++]= '<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">'
-        @additionalJs[indeksJ++] = '<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>'
-      else if array[i] == 'foundation'
-        @additionalStyles[indeksS++] = '<link href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.2.0/foundation.min.css" rel="stylesheet">'
-        @additionalJs[indeksJ++] = '<script src="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.2.0/foundation.min.js"></script>'
-      else if array[i] == 'jquery_1.12.1'
-        @additionalJs[indeksJ++] = '<script src="https://code.jquery.com/jquery-1.12.1.min.js"></script>'
-      else if array[i] == 'jquery_2.2.1'
-        @additionalJs[indeksJ++] = '<script src="https://code.jquery.com/jquery-2.2.1.min.js"></script>'
-      else if array[i] == 'fontAwesome'
-        @additionalStyles[indeksS++]= '<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">'
-      else if array[i] == 'mdi'
-        @additionalStyles[indeksS++]= '<link rel="stylesheet" href="https://cdn.materialdesignicons.com/1.4.57/css/materialdesignicons.min.css">'
+    addResource: (array) ->
+        indeksS = indeksJ = 0
+        for i in [0...array.length] by 1
+            if array[i] == 'bootstrap'
+                @additionalStyles[indeksS++]= '<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">'
+                @additionalJs[indeksJ++] = '<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>'
+            else if array[i] == 'foundation'
+                @additionalStyles[indeksS++] = '<link href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.2.0/foundation.min.css" rel="stylesheet">'
+                @additionalJs[indeksJ++] = '<script src="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.2.0/foundation.min.js"></script>'
+            else if array[i] == 'jquery_1.12.1'
+                @additionalJs[indeksJ++] = '<script src="https://code.jquery.com/jquery-1.12.1.min.js"></script>'
+            else if array[i] == 'jquery_2.2.1'
+                @additionalJs[indeksJ++] = '<script src="https://code.jquery.com/jquery-2.2.1.min.js"></script>'
+            else if array[i] == 'fontAwesome'
+                @additionalStyles[indeksS++]= '<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">'
+            else if array[i] == 'mdi'
+                @additionalStyles[indeksS++]= '<link rel="stylesheet" href="https://cdn.materialdesignicons.com/1.4.57/css/materialdesignicons.min.css">'
 
-  returnAdd: (array) ->
-    scripts = " "
-    for i in [0...array.length] by 1
-      if array[i] != null||undefined
-        scripts+='\n\t'
-        scripts +=array[i]
-    return scripts
+    returnAdd: (array) ->
+        scripts = " "
+        for i in [0...array.length] by 1
+            if array[i] != null||undefined
+                scripts+='\n\t'
+                scripts +=array[i]
+        return scripts
 
 
-  toggle: ->
-    defaultGrammarScopeName =  "text.html.basic"
-    if editor=atom.workspace.getActiveTextEditor()
-       value = editor.lineTextForScreenRow(editor.getLastScreenRow())
-       valueArr = value.split "-"
-       if valueArr != null||undefined||""
-         @addResource(valueArr)
-         console.log(valueArr)
-       console.log(@additionalStyles)
-       if valueArr[0] == "html5"
-           @templateForm = """
-              <!DOCTYPE html>
-              <html lang="es">
+    toggle: ->
+        defaultGrammarScopeName = "text.html.basic"
+        if editor=atom.workspace.getActiveTextEditor()
+            value = editor.lineTextForScreenRow(editor.getLastScreenRow())
+            valueArr = value.split "-"
+            if valueArr != null||undefined||""
+                @addResource(valueArr)
+                console.log(valueArr)
+                console.log(@additionalStyles)
+            if valueArr[0] == "html5"
+                @templateForm = """
+                                <!DOCTYPE html>
+                                <html lang="es">
 
-              <head>
-                  <meta charset="UTF-8">
-                  <title>Título</title>
-                  <meta name="description" content="Descripción">
-                  #{@returnAdd(@additionalStyles)}
-                  #{@defaultStyles}
-                  <!-- Para compatibilidad con Internet Explorer 9 -->
-                  <!--[if lt IE 9]>
-                    <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-                  <![endif]-->
-              </head>
+                                <head>
+                                    <meta charset="UTF-8">
+                                    <title>Título</title>
+                                    <meta name="description" content="Descripción">
+                                    #{@defaultStyles}
+                                    #{@returnAdd(@additionalStyles)}
+                                    <!-- Para compatibilidad con Internet Explorer 9 -->
+                                    <!--[if lt IE 9]>
+                                      <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+                                    <![endif]-->
+                                </head>
 
-              <body>
-              #{@returnAdd(@additionalJs)}
-              </body>
+                                <body>
+                                #{@returnAdd(@additionalJs)}
+                                </body>
 
-              </html>
-              """
-       else
-        @templateForm="No existe tal opción."
+                                </html>
+                                """
+            else if valueArr[0] == "xhtml"
+                @templateForm="XHTML"
+            else
+                @templateForm="No existe tal opción."
 
-    editor.setText(@templateForm)
-    editor.setGrammar(atom.grammars.grammarForScopeName(defaultGrammarScopeName))
+        editor.setText(@templateForm)
+        editor.setGrammar(atom.grammars.grammarForScopeName(defaultGrammarScopeName))

--- a/spec/atom-html-templates-spec.coffee
+++ b/spec/atom-html-templates-spec.coffee
@@ -27,7 +27,7 @@ describe "AtomHtmlTemplates", ->
       activationPromise
 
     runs ->
-      expect(editor.getText()).toEqual("nie ma takiej opcji")
+      expect(editor.getText()).toEqual("No existe tal opción.")
 
   it " html5 text", ->
       editor = atom.workspace.getActiveTextEditor()
@@ -41,24 +41,24 @@ describe "AtomHtmlTemplates", ->
 
       runs ->
         expect(editor.getText().replace /\s+/g, '').toEqual """
-          <!doctype html>
-          <html lang="en">
+          <!DOCTYPE html>
+          <html lang="es">
+
           <head>
             <meta charset ="utf-8">
+            <title>Título</title>
+            <meta name = "description" content="Descripción">
 
-            <title>Title of your project</title>
-            <meta name = "description" content="The HTML5 Herald">
-            <meta name = "author" content="SitePoint">
-
-            <link rel = "stylesheet" href="css/styles.css?v=1.0">
-
+            <!-- Para compatibilidad con Internet Explorer 9 -->
             <!--[if lt IE 9]>
             <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
             <![endif]-->
           </head>
+
           <body>
-            <script src = "js/scripts.js"></script>
+
           </body>
+
           </html>
         """.replace /\s+/g, ''
     it " bootstrap-foundation text", ->

--- a/spec/atom-html-templates-spec.coffee
+++ b/spec/atom-html-templates-spec.coffee
@@ -45,14 +45,14 @@ describe "AtomHtmlTemplates", ->
           <html lang="es">
 
           <head>
-            <meta charset ="utf-8">
-            <title>Título</title>
-            <meta name = "description" content="Descripción">
-
-            <!-- Para compatibilidad con Internet Explorer 9 -->
-            <!--[if lt IE 9]>
-            <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-            <![endif]-->
+              <meta charset="UTF-8">
+              <title>Título</title>
+              <meta name="description" content="Descripción">
+              <link rel="stylesheet" href="RUTA">
+              <!-- Para compatibilidad con Internet Explorer 9 -->
+              <!--[if lt IE 9]>
+                <script src = "http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+              <![endif]-->
           </head>
 
           <body>


### PR DESCRIPTION
- Another option to create xhtml template for EPUB (called `epub`) was added.
- More defaults were added.
- Some translation of Polish to English was made.
- Bug fix: clear the additional js and css after the creation of the template, allowing to rerun with clean variables.
